### PR TITLE
Fix: no longer displays skill wait time when it's zero seconds.

### DIFF
--- a/player-events.js
+++ b/player-events.js
@@ -62,8 +62,11 @@ module.exports = {
 
     commandQueued: state => function (commandIndex) {
       const command = this.commandQueue.queue[commandIndex];
-      const ttr = sprintf('%.1f', this.commandQueue.getTimeTilRun(commandIndex));
-      B.sayAt(this, `<bold><yellow>Executing</yellow> '<white>${command.label}</white>' <yellow>in</yellow> <white>${ttr}</white> <yellow>seconds.</yellow>`);
+      let ttr = this.commandQueue.getTimeTilRun(commandIndex);
+      if (ttr > 0) {
+        ttr = sprintf('%.1f', this.commandQueue.getTimeTilRun(commandIndex));
+        B.sayAt(this, `<bold><yellow>Executing</yellow> '<white>${command.label}</white>' <yellow>in</yellow> <white>${ttr}</white> <yellow>seconds.</yellow>`);
+      }
     },
 
     updateTick: state => function () {


### PR DESCRIPTION
Currently, when you use a skill or cast a spell, it's added to the queue with a lag time, which helps determine when it will be performed.  However, if the skill/spell is the first in the queue, the lag is ignored, and the skill/spell is immediately cast.  Yet the game still prints out messages like:
`Executing 'cast Fireball' in 0.0 seconds.`
This change prevents this "Executing" info from being displayed when the lag time is zero.